### PR TITLE
Allows Repository used as a crate dependency directly by adding Cargo workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ crate/Cargo.lock
 webpack_demo/node_modules
 webpack_demo/dist
 webpack_demo/package-lock.json
+target
+/cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = [
+    "crate"
+]


### PR DESCRIPTION
This will allows users to use gdl as cargo dependency like this:

`gdl = { git = "https://github.com/silvia-odwyer/gdl", branch = "master" }`